### PR TITLE
add gcd tests

### DIFF
--- a/src/test/scala/gcd/DecoupledGcd.scala
+++ b/src/test/scala/gcd/DecoupledGcd.scala
@@ -1,0 +1,78 @@
+package gcd
+
+// source:
+// https://github.com/ucb-bar/testers-regression/blob/94e23d1ee1bfc137ecd5a541a1b094fd0feb229f/src/main/scala/gcd/DecoupledGCD.scala
+
+import chisel3._
+import chisel3.util.Decoupled
+
+class GcdInputBundle(val w: Int) extends Bundle {
+  val value1 = UInt(w.W)
+  val value2 = UInt(w.W)
+}
+
+class GcdOutputBundle(override val w: Int) extends GcdInputBundle(w) {
+  val gcd    = UInt(w.W)
+}
+
+/**
+ * Compute Gcd using subtraction method.
+ * Subtracts the smaller from the larger until register y is zero.
+ * value input register x is then the Gcd.
+ * Unless first input is zero then the Gcd is y.
+ * Can handle stalls on the producer or consumer side
+ */
+class DecoupledGcd(val bitWidth: Int) extends MultiIOModule {
+  val input = IO(Flipped(Decoupled(new GcdInputBundle(bitWidth))))
+  val output = IO(Decoupled(new GcdOutputBundle(bitWidth)))
+
+  val xInitial    = Reg(UInt(bitWidth.W))
+  val yInitial    = Reg(UInt(bitWidth.W))
+  val x           = Reg(UInt(bitWidth.W))
+  val y           = Reg(UInt(bitWidth.W))
+  val busy        = RegInit(false.B)
+  val resultValid = RegInit(false.B)
+
+  input.ready := ! busy
+  output.valid := resultValid
+  output.bits := DontCare
+
+  val cycle = RegInit(0.U(32.W))
+  cycle := cycle + 1.U
+
+  //  printf("%d xi  %d yi  %d c  %d x  %d y  %d busy  %d valid  out\n",
+  //    xInitial, yInitial, cycle, x, y, busy.asUInt, resultValid.asUInt)
+
+  when(busy)  {
+    when(x >= y) {
+      x := x - y
+    }.otherwise {
+      y := y - x
+    }
+    when(x === 0.U || y === 0.U) {
+      when(x === 0.U) {
+        output.bits.gcd := y
+      }.otherwise {
+        output.bits.gcd := x
+      }
+
+      output.bits.value1 := xInitial
+      output.bits.value2 := yInitial
+      resultValid := true.B
+
+      when(output.ready && resultValid) {
+        busy := false.B
+        resultValid := false.B
+      }
+    }
+  }.otherwise {
+    when(input.valid) {
+      val bundle = input.deq()
+      x := bundle.value1
+      y := bundle.value2
+      xInitial := bundle.value1
+      yInitial := bundle.value2
+      busy := true.B
+    }
+  }
+}

--- a/src/test/scala/gcd/DecoupledGcdChiseltestTester.scala
+++ b/src/test/scala/gcd/DecoupledGcdChiseltestTester.scala
@@ -1,0 +1,185 @@
+package gcd
+
+import chisel3._
+import chisel3.experimental.BundleLiterals._
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation}
+import chiseltest._
+import chiseltest.internal.NoThreadingAnnotation
+import chiseltest.simulator.{SimulatorAnnotation, SimulatorContext}
+import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.FirrtlCircuitAnnotation
+import firrtl.{AnnotationSeq, EmittedCircuitAnnotation}
+import logger.LogLevelAnnotation
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DecoupledGcdChiseltestTester extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "DecoupledGcd"
+
+  // play with these to adjust test execution time
+  val (maxX, maxY) = (100, 100)
+  val testValues = for {x <- 2 to maxX; y <- 2 to maxY} yield (BigInt(x), BigInt(y), BigInt(x).gcd(y))
+  val bitWidth = 60
+
+
+  def runWithChiseltestThreads(backend: SimulatorAnnotation): Unit = {
+    val simName = backend.getSimulator.name
+    val inputBundles = testValues.map { case (a, b, _) =>
+      new GcdInputBundle(bitWidth).Lit(_.value1 -> a.U, _.value2 -> b.U)
+    }
+    val outputBundles = testValues.map { case (a, b, c) =>
+      new GcdOutputBundle(bitWidth).Lit(_.value1 -> a.U, _.value2 -> b.U, _.gcd -> c.U)
+    }
+
+    val startElab = System.nanoTime()
+    test(new DecoupledGcd(bitWidth)).withAnnotations(Seq(backend)) { dut =>
+      println(s"Took ${(System.nanoTime() - startElab) / 1e9d}s to elaborate, compile and create simulation w/ $simName")
+      val startTest = System.nanoTime()
+
+      dut.reset.poke(true.B)
+      dut.clock.step(2)
+      dut.reset.poke(false.B)
+
+      dut.input.initSource().setSourceClock(dut.clock)
+      dut.output.initSink().setSinkClock(dut.clock)
+      dut.clock.setTimeout(0)
+
+      fork {
+        dut.input.enqueueSeq(inputBundles)
+      }.fork {
+        dut.output.expectDequeueSeq(outputBundles)
+      }.join()
+
+      val deltaSeconds = (System.nanoTime() - startTest) / 1e9d
+      println(s"Took ${deltaSeconds}s to run test with chiseltest threads w/ $simName")
+    }
+  }
+
+  private def runTestDut(dut: DecoupledGcd, testValues: Iterable[(BigInt, BigInt, BigInt)]): Long = {
+    var cycles = 0L
+    dut.reset.poke(true.B)
+    dut.clock.step(2)
+    cycles += 2
+    dut.reset.poke(false.B)
+
+    dut.output.ready.poke(true.B)
+    for((i, j, expected) <- testValues) {
+      dut.input.bits.value1.poke(i.U)
+      dut.input.bits.value2.poke(j.U)
+      dut.input.valid.poke(true.B)
+      dut.clock.step(1)
+      cycles += 1
+
+      while(!dut.output.valid.peek().litToBoolean) {
+        dut.clock.step(1)
+        cycles += 1
+      }
+      dut.output.bits.gcd.expect(expected.U)
+      dut.output.valid.expect(true.B)
+    }
+
+    cycles
+  }
+
+  def runWithChiseltestSingleThread(backend: SimulatorAnnotation): Unit = {
+    val simName = backend.getSimulator.name
+    val startElab = System.nanoTime()
+    test(new DecoupledGcd(bitWidth)).withAnnotations(Seq(backend, NoThreadingAnnotation)) { dut =>
+      println(s"Took ${(System.nanoTime() - startElab) / 1e9d}s to elaborate, compile and create simulation w/ $simName")
+      val startTest = System.nanoTime()
+      val cycles = runTestDut(dut, testValues)
+      val deltaSeconds = (System.nanoTime() - startTest) / 1e9d
+      println(s"Took ${deltaSeconds}s to run test with chiseltest but no threads w/ $simName")
+      println(s"Executed $cycles cycles at an average frequency of ${cycles / deltaSeconds} Hz")
+    }
+  }
+
+
+  private def runTestSim(dut: SimulatorContext, testValues: Iterable[(BigInt, BigInt, BigInt)]): Long = {
+    var cycles = 0L
+    dut.poke("reset", 1)
+    dut.step(2)
+    cycles += 2
+    dut.poke("reset", 0)
+
+    dut.poke("output_ready", 1)
+    for((i, j, expected) <- testValues) {
+      dut.poke("input_bits_value1", i)
+      dut.poke("input_bits_value2", j)
+      dut.poke("input_valid", 1)
+      dut.step(1)
+      cycles += 1
+
+      while(dut.peek("output_valid") == 0) {
+        dut.step(1)
+        cycles += 1
+      }
+      assert(dut.peek("output_bits_gcd") == expected)
+      assert(dut.peek("output_valid") == 1)
+    }
+
+    cycles
+  }
+
+  def runWithRawSimSingleThread(backend: SimulatorAnnotation): Unit = {
+    val simName = backend.getSimulator.name
+
+    val startElab = System.nanoTime()
+
+    // elaborate and compile to low firrtl
+    val targetDir = TargetDirAnnotation("test_run_dir/gcd_raw_sim_with_" + simName)
+    val stage = new chisel3.stage.ChiselStage()
+    val r = stage.run(Seq(
+      ChiselGeneratorAnnotation(() => new DecoupledGcd(bitWidth)),
+      targetDir,
+    ))
+    val state = annosToState(r)
+    val dut = backend.getSimulator.createContext(state)
+
+    println(s"Took ${(System.nanoTime() - startElab) / 1e9d}s to elaborate, compile and create simulation w/ $simName")
+
+    val startTest = System.nanoTime()
+    val cycles = runTestSim(dut, testValues)
+    val deltaSeconds = (System.nanoTime() - startTest) / 1e9d
+    println(s"Took ${deltaSeconds}s to run test with the raw simulator interface and no threads w/ $simName")
+    println(s"Executed $cycles cycles at an average frequency of ${cycles / deltaSeconds} Hz")
+
+  }
+
+  // copied over from chiseltest
+  private def annosToState(annos: AnnotationSeq): firrtl.CircuitState = {
+    val circuit = annos.collectFirst { case FirrtlCircuitAnnotation(c) => c }.get
+    val filteredAnnos = annos.filterNot(isInternalAnno)
+    firrtl.CircuitState(circuit, filteredAnnos)
+  }
+  private def isInternalAnno(a: Annotation): Boolean = a match {
+    case _: FirrtlCircuitAnnotation | _: DesignAnnotation[_] | _: ChiselCircuitAnnotation | _: DeletedAnnotation |
+         _: EmittedCircuitAnnotation[_] | _: LogLevelAnnotation =>
+      true
+    case _ => false
+  }
+
+  it should  "work with chiseltest threads and treadle" in {
+    runWithChiseltestThreads(TreadleBackendAnnotation)
+  }
+
+  it should  "work with chiseltest threads and verilator" in {
+    runWithChiseltestThreads(VerilatorBackendAnnotation)
+  }
+
+  it should  "work with chiseltest single threaded and treadle" in {
+    runWithChiseltestSingleThread(TreadleBackendAnnotation)
+  }
+
+  it should  "work with chiseltest single threaded and verilator" in {
+    runWithChiseltestSingleThread(VerilatorBackendAnnotation)
+  }
+
+  it should  "work with raw simulator and single threaded and treadle" in {
+    runWithRawSimSingleThread(TreadleBackendAnnotation)
+  }
+
+  it should  "work with raw simulator and single threaded and verilator" in {
+    runWithRawSimSingleThread(VerilatorBackendAnnotation)
+  }
+}


### PR DESCRIPTION
```
Took 3.777360577s to elaborate, compile and create simulation w/ treadle
Took 30.80544017s to run test with chiseltest threads w/ treadle

Took 3.064748781s to elaborate, compile and create simulation w/ verilator
Took 28.900293132s to run test with chiseltest threads w/ verilator

Took 0.371683805s to elaborate, compile and create simulation w/ treadle
Took 0.963317774s to run test with chiseltest but no threads w/ treadle
Executed 164741 cycles at an average frequency of 171014.18083042657 Hz

Took 2.534736691s to elaborate, compile and create simulation w/ verilator
Took 0.596289081s to run test with chiseltest but no threads w/ verilator
Executed 164741 cycles at an average frequency of 276277.0697120982 Hz

Took 0.42027536s to elaborate, compile and create simulation w/ treadle
Took 0.627706681s to run test with the raw simulator interface and no threads w/ treadle
Executed 164741 cycles at an average frequency of 262449.01478115696 Hz

Took 2.63678169s to elaborate, compile and create simulation w/ verilator
Took 0.399520852s to run test with the raw simulator interface and no threads w/ verilator
Executed 164741 cycles at an average frequency of 412346.4374270007 Hz

```

But beware some JVM warmup effects. A fairer comparison might run each test from a cold start or performe some warmup routines.